### PR TITLE
Add encoder support for hall effect commutation with Broadcom AEAT6012 position estimation

### DIFF
--- a/Firmware/Board/v3/Inc/board.h
+++ b/Firmware/Board/v3/Inc/board.h
@@ -92,7 +92,7 @@ using TOpAmp = Drv8301;
 extern std::array<Axis, AXIS_COUNT> axes;
 extern Motor motors[AXIS_COUNT];
 extern OnboardThermistorCurrentLimiter fet_thermistors[AXIS_COUNT];
-extern Encoder encoders[AXIS_COUNT];
+extern Encoder encoders[AXIS_COUNT][2];
 extern Stm32Gpio gpios[GPIO_COUNT];
 
 struct GpioFunction { int mode = 0; uint8_t alternate_function = 0xff; };

--- a/Firmware/Board/v3/board.cpp
+++ b/Firmware/Board/v3/board.cpp
@@ -93,22 +93,42 @@ Motor motors[AXIS_COUNT] = {
     }
 };
 
-Encoder encoders[AXIS_COUNT] = {
+Encoder encoders[AXIS_COUNT][2] = {
     {
-        &htim3, // timer
-        {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // index_gpio
-        {M0_ENC_A_GPIO_Port, M0_ENC_A_Pin}, // hallA_gpio
-        {M0_ENC_B_GPIO_Port, M0_ENC_B_Pin}, // hallB_gpio
-        {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // hallC_gpio
-        &spi3_arbiter // spi_arbiter
+        {
+            &htim3, // timer
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // index_gpio
+            {M0_ENC_A_GPIO_Port, M0_ENC_A_Pin}, // hallA_gpio
+            {M0_ENC_B_GPIO_Port, M0_ENC_B_Pin}, // hallB_gpio
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // hallC_gpio
+            &spi3_arbiter // spi_arbiter
+        },
+        {
+            &htim3, // timer
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // index_gpio
+            {M0_ENC_A_GPIO_Port, M0_ENC_A_Pin}, // hallA_gpio
+            {M0_ENC_B_GPIO_Port, M0_ENC_B_Pin}, // hallB_gpio
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // hallC_gpio
+            &spi3_arbiter // spi_arbiter
+        }
     },
     {
-        &htim4, // timer
-        {M1_ENC_Z_GPIO_Port, M1_ENC_Z_Pin}, // index_gpio
-        {M1_ENC_A_GPIO_Port, M1_ENC_A_Pin}, // hallA_gpio
-        {M1_ENC_B_GPIO_Port, M1_ENC_B_Pin}, // hallB_gpio
-        {M1_ENC_Z_GPIO_Port, M1_ENC_Z_Pin}, // hallC_gpio
-        &spi3_arbiter // spi_arbiter
+        {
+            &htim4, // timer
+            {M1_ENC_Z_GPIO_Port, M1_ENC_Z_Pin}, // index_gpio
+            {M1_ENC_A_GPIO_Port, M1_ENC_A_Pin}, // hallA_gpio
+            {M1_ENC_B_GPIO_Port, M1_ENC_B_Pin}, // hallB_gpio
+            {M1_ENC_Z_GPIO_Port, M1_ENC_Z_Pin}, // hallC_gpio
+            &spi3_arbiter // spi_arbiter
+        },
+        {
+            &htim4, // timer
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // index_gpio
+            {M0_ENC_A_GPIO_Port, M0_ENC_A_Pin}, // hallA_gpio
+            {M0_ENC_B_GPIO_Port, M0_ENC_B_Pin}, // hallB_gpio
+            {M0_ENC_Z_GPIO_Port, M0_ENC_Z_Pin}, // hallC_gpio
+            &spi3_arbiter // spi_arbiter
+        }
     }
 };
 
@@ -126,7 +146,8 @@ std::array<Axis, AXIS_COUNT> axes{{
         1, // step_gpio_pin
         2, // dir_gpio_pin
         (osPriority)(osPriorityHigh + (osPriority)1), // thread_priority
-        encoders[0], // encoder
+        encoders[0][0], // encoder
+        encoders[0][1], // encoder2
         sensorless_estimators[0], // sensorless_estimator
         controllers[0], // controller
         motors[0], // motor
@@ -144,7 +165,8 @@ std::array<Axis, AXIS_COUNT> axes{{
         4, // dir_gpio_pin
 #endif
         osPriorityHigh, // thread_priority
-        encoders[1], // encoder
+        encoders[1][0], // encoder
+        encoders[1][1], // encoder2
         sensorless_estimators[1], // sensorless_estimator
         controllers[1], // controller
         motors[1], // motor

--- a/Firmware/MotorControl/axis.hpp
+++ b/Firmware/MotorControl/axis.hpp
@@ -108,6 +108,7 @@ public:
             uint16_t default_dir_gpio_pin,
             osPriority thread_priority,
             Encoder& encoder,
+            Encoder& encoder2,
             SensorlessEstimator& sensorless_estimator,
             Controller& controller,
             Motor& motor,
@@ -158,6 +159,7 @@ public:
     Config_t config_;
 
     Encoder& encoder_;
+    Encoder& encoder2_;
     AcimEstimator acim_estimator_;
     SensorlessEstimator& sensorless_estimator_;
     Controller& controller_;
@@ -168,6 +170,8 @@ public:
     Endstop& max_endstop_;
     MechanicalBrake& mechanical_brake_;
     TaskTimes task_times_;
+
+    bool use_2_encoders_ = false;
 
     osThreadId thread_id_ = 0;
     const uint32_t stack_size_ = 2048; // Bytes

--- a/Firmware/MotorControl/encoder.cpp
+++ b/Firmware/MotorControl/encoder.cpp
@@ -594,6 +594,11 @@ void Encoder::abs_spi_cb(bool success) {
             pos = (rawVal >> 2) & 0x3fff;
         } break;
 
+        case MODE_SPI_ABS_AEAT: {
+            uint16_t rawVal = abs_spi_dma_rx_[0];
+            pos = (rawVal >> 3) & 0xfff;
+        } break;
+
         default: {
            set_error(ERROR_UNSUPPORTED_ENCODER_MODE);
            goto done;


### PR DESCRIPTION
Allow us to use halls for BLDC commutation and absolute SPI encoders ([AEAT-6012-A06](https://www.broadcom.com/products/motion-control-encoders/magnetic-encoders/aeat-6012-a06)) mounted post reduction to track joint position